### PR TITLE
Fix chinese locale detection

### DIFF
--- a/sdk/others/isInChina.js
+++ b/sdk/others/isInChina.js
@@ -9,7 +9,7 @@ class IsInChina {
     let result
     try {
       result =
-        new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).indexOf('zh_CN')
+        new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).includes('zh_CN')
     } catch (e) {
       result = false
     }


### PR DESCRIPTION
When given substring doesn't exist in a string, `indexOf()` returns `-1` which is truthy.

This patch fixes locale detection issue.