### PR TITLE
Fix and improve IsInChina resolution

### DIFF
--- a/sdk/others/isInChina.js
+++ b/sdk/others/isInChina.js
@@ -6,13 +6,12 @@ class IsInChina {
       new DataReport().report({ name: 'DetectChinaUser' })
     } catch (e) {}
 
-    let result
-    try {
-      result =
-        new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).includes('zh_CN')
-    } catch (e) {
-      result = false
-    }
+    const result =
+      process.env.SLS_GEO_LOCATION === 'cn' ||
+      new Intl.DateTimeFormat('en', { timeZoneName: 'long' })
+        .format()
+        .includes('China Standard Time')
+
     return { IsInChina: result }
   }
 }


### PR DESCRIPTION
- Timezone difference also covers users outside of China (e.g. in Western Australia)
- System locale may affect Chinese users that are outside of China

Hence limited detection to `CST` (China Standard Time) timezone which is effective only for users in China.

Additionally added support for SLS_GEO_LOCATION through that detection will be in line with one we have in other Serverless utilities: https://github.com/serverless/components/blob/449c154b31d585cefa7d03f0a1c06dc347277b60/src/cli/utils.js#L350-L357