### PR TITLE
forward CLI output to the caller of remoteDebug function

### DIFF
--- a/sdk/debug/index.js
+++ b/sdk/debug/index.js
@@ -8,7 +8,7 @@ const RemoteDebug = function(auth, func, Region = 'ap-guangzhou') {
   this.request = new ApiRequest(auth, func, Region)
 }
 
-RemoteDebug.prototype.remoteDebug = async function() {
+RemoteDebug.prototype.remoteDebug = async function(cliCallback) {
   try {
     await this.request.ensureFunctionState()
     await this.request.startDebugging()
@@ -22,22 +22,24 @@ RemoteDebug.prototype.remoteDebug = async function() {
     this.client = new WshubClient({ Url, Token })
     try {
       await this.client.forwardDebug()
-      console.log('Debugging listening on ws://127.0.0.1:9222.')
-      console.log('For help see https://nodejs.org/en/docs/inspector.')
-      console.log(
+      cliCallback('Debugging listening on ws://127.0.0.1:9222.')
+      cliCallback('For help see https://nodejs.org/en/docs/inspector.')
+      cliCallback(
         'Please open chorme, and visit chrome://inspect, click [Open dedicated DevTools for Node] to debug your code.'
       )
     } catch (e) {
-      console.error('Debug init error. Please confirm if the local port 9222 is used')
+      cliCallback('Debug init error. Please confirm if the local port 9222 is used', {
+        type: 'error'
+      })
     }
-    console.log('--------------------- The realtime log ---------------------')
-    await this.client.forwardLog()
+    cliCallback('--------------------- The realtime log ---------------------')
+    await this.client.forwardLog(cliCallback.stdout)
   } catch (e) {
-    console.error(e.message)
+    cliCallback(e.message, { type: 'error' })
   }
 }
 
-RemoteDebug.prototype.stop = async function() {
+RemoteDebug.prototype.stop = async function(cliCallback) {
   try {
     if (this.client) {
       this.client.close()
@@ -48,7 +50,7 @@ RemoteDebug.prototype.stop = async function() {
       await this.request.stopDebugging()
     }
   } catch (e) {
-    console.error(e.message)
+    cliCallback(e.message, { type: 'error' })
   }
 }
 

--- a/sdk/debug/lib/client.js
+++ b/sdk/debug/lib/client.js
@@ -1,71 +1,70 @@
-const { default: connect } = require('./wshub-client');
-const { default: createLogger } = require('./wshub-logger');
+const { default: connect } = require('./wshub-client')
+const { default: createLogger } = require('./wshub-logger')
 
-const duplex = require('duplexify');
+const duplex = require('duplexify')
 
-const Client = function (options) {
-    const {
-        Url,
-        Token,
-        logType = 'error',
-        localPort = 9222,
-        debugRemotePort = 9000,
-        logRemotePort = 3332,
-        timeout,
-    } = options
-    //日志类型，verbose或者info，测试阶段建议verbose
-    this.logger = createLogger(logType)
-    //映射的本地端口，默认9222
-    this.localPort = localPort
-    //远端调试端口，默认9000
-    this.debugRemotePort = debugRemotePort
-    //远端日志端口，默认3222
-    this.logRemotePort = logRemotePort
-    //连接wshub的超时时间
-    this.timeout = timeout
-    this.Url = Url
-    this.Token = Token
+const Client = function(options) {
+  const {
+    Url,
+    Token,
+    logType = 'error',
+    localPort = 9222,
+    debugRemotePort = 9000,
+    logRemotePort = 3332,
+    timeout
+  } = options
+  //日志类型，verbose或者info，测试阶段建议verbose
+  this.logger = createLogger(logType)
+  //映射的本地端口，默认9222
+  this.localPort = localPort
+  //远端调试端口，默认9000
+  this.debugRemotePort = debugRemotePort
+  //远端日志端口，默认3222
+  this.logRemotePort = logRemotePort
+  //连接wshub的超时时间
+  this.timeout = timeout
+  this.Url = Url
+  this.Token = Token
 }
 
 /**
  * connect to ws-hub service
  * @returns the client promise
  */
-Client.prototype._connect = async function () {
-    return connect({ url: this.Url, token: this.Token, logger: this.logger, timeout: this.timeout })
+Client.prototype._connect = async function() {
+  return connect({ url: this.Url, token: this.Token, logger: this.logger, timeout: this.timeout })
 }
-
 
 /**
  * forward for debug
  * @returns the client local port
  */
-Client.prototype.forwardDebug = async function () {
-    if (!this.client) {
-        this.client = await this._connect()
-    }
-    return this.client.forward(this.localPort, this.debugRemotePort);
+Client.prototype.forwardDebug = async function() {
+  if (!this.client) {
+    this.client = await this._connect()
+  }
+  return this.client.forward(this.localPort, this.debugRemotePort)
 }
 
 /**
  * forward for real time log
  * @returns the client local port
  */
-Client.prototype.forwardLog = async function () {
-    if (!this.client) {
-        this.client = await this._connect()
-    }
-    return this.client.forward(duplex(process.stdout, null, { end: false }), this.logRemotePort)
+Client.prototype.forwardLog = async function(stdout) {
+  if (!this.client) {
+    this.client = await this._connect()
+  }
+  return this.client.forward(duplex(stdout, null, { end: false }), this.logRemotePort)
 }
 
 /**
  * close the client
  * @returns close result
  */
-Client.prototype.close = async function () {
-    if (this.client) {
-        return this.client.close()
-    }
+Client.prototype.close = async function() {
+  if (this.client) {
+    return this.client.close()
+  }
 }
 
 module.exports = Client


### PR DESCRIPTION
By doing this forward, serverless framework has control of all CLI
user interface, so it will be easier to have unified interface
control and task like adding color or wrapping line will be easy
and they're all put in one place